### PR TITLE
Few whitespace and cleanups + finishing up osc group list

### DIFF
--- a/osc-group.py
+++ b/osc-group.py
@@ -19,6 +19,9 @@ def _print_version(self):
     print('{0}'.format(self.OSC_GROUP_VERSION))
     quit(0)
 
+def _extract(attr, type_, from_, root):
+    return [type_(x.attrib[attr]) for x in root.findall(from_)]
+
 def _group_find_request_id(self, submit_request, opts):
     """
     Look up the submit_request by ID to verify if it is correct
@@ -30,9 +33,7 @@ def _group_find_request_id(self, submit_request, opts):
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
-    res = []
-    for rq in root.findall('request'):
-        res.append(int(rq.attrib['id']))
+    res = _extract('id', int, 'request', root)
 
     # we have various stuff passed, and it might or might not be int we need for the comparison
     try:
@@ -57,9 +58,7 @@ def _group_find_request_package(self, package, opts):
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
-    res = []
-    for rq in root.findall('request'):
-        res.append(int(rq.attrib['id']))
+    res = _extract('id', int, 'request', root)
 
     if len(res) > 1:
         raise oscerr.ServiceRuntimeError('There are multiple requests for package "{0}"'.format(package))
@@ -105,9 +104,7 @@ def _group_find_request_group(self, request, opts):
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
-    res = []
-    for rq in root.findall('request'):
-        res.append(int(rq.attrib['id']))
+    res = _extract('id', int, 'request', root)
 
     if len(res) > 1:
         raise oscerr.ServiceRuntimeError('There are multiple group requests for package "{0}". This should not happen.'.format(request))
@@ -187,9 +184,7 @@ def _group_verify_type(self, grid, opts):
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
-    res = []
-    for rq in root.findall('request'):
-        res.append(int(rq.attrib['id']))
+    res = _extract('id', int, 'request', root)
 
     # we have various stuff passed, and it might or might not be int we need for the comparison
     try:
@@ -323,15 +318,13 @@ def _group_list_requests(self, grid, opts):
     :param opts: obs options
     """
 
-    res = []
     if not grid:
         # search up the GR#s
         url = makeurl(opts.apiurl, ['search', 'request', 'id?match=(action/@type=\'group\'%20and%20(state/@name=\'new\'%20or@20state/@name=\'review\'))'] )
         f = http_GET(url)
         root = ET.parse(f).getroot()
 
-        for rq in root.findall('request'):
-            res.append(int(rq.attrib['id']))
+        res = _extract('id', int, 'request', root)
 
         print('Listing current open grouping requests...')
         for rq in res:

--- a/osc-group.py
+++ b/osc-group.py
@@ -318,21 +318,22 @@ def _group_list_requests(self, grid, opts):
     :param opts: obs options
     """
 
-    if not grid:
-        # search up the GR#s
-        url = makeurl(opts.apiurl, ['search', 'request', 'id?match=(action/@type=\'group\'%20and%20(state/@name=\'new\'%20or@20state/@name=\'review\'))'] )
-        f = http_GET(url)
-        root = ET.parse(f).getroot()
+    # FIXME: find all requests in grouping request and print their content
+    #        currently the we have to search for all grouping requests and then filter for proper id, highly suboptimal
 
-        res = _extract('id', int, 'request', root)
-
-        print('Listing current open grouping requests...')
-        for rq in res:
-            self._print_group_header(rq, opts)
-    else:
+    if grid:
         self._print_group_header(grid, opts)
-        # FIXME: find all requests in grouping request and print their content
-        #        currently the we have to search for all grouping requests and then filter for proper id, highly suboptimal
+        return
+
+    # search up the GR#s
+    url = makeurl(opts.apiurl, ['search', 'request', 'id?match=(action/@type=\'group\'%20and%20(state/@name=\'new\'%20or@20state/@name=\'review\'))'] )
+    f = http_GET(url)
+    root = ET.parse(f).getroot()
+
+    print('Listing current open grouping requests...')
+    for rq in _extract('id', int, 'request', root):
+        self._print_group_header(rq, opts)
+
 
 @cmdln.option('-v', '--version', action='store_true',
               dest='version',

--- a/osc-group.py
+++ b/osc-group.py
@@ -110,7 +110,7 @@ def _group_find_request_group(self, request, opts):
         res.append(int(rq.attrib['id']))
         
     if len(res) > 1:
-        raise oscerr.ServiceRuntimeError('There are multiple group requests for package "{0}". This should not happen.'.format(package))
+        raise oscerr.ServiceRuntimeError('There are multiple group requests for package "{0}". This should not happen.'.format(request))
 
     if len(res) == 0 or res[0] == 0:
         #raise oscerr.ServiceRuntimeError('There is no grouping request for package "{0}"'.format(package))

--- a/osc-group.py
+++ b/osc-group.py
@@ -16,7 +16,7 @@ OSC_GROUP_VERSION='0.0.3'
 def _print_version(self):
     """ Print version information about this extension. """
 
-    print('%s' % self.OSC_GROUP_VERSION)
+    print('{0}'.format(self.OSC_GROUP_VERSION))
     quit(0)
 
 def _group_find_request_id(self, submit_request, opts):
@@ -227,7 +227,7 @@ def _group_create(self, name, pkgs, opts):
     f = http_POST(u, data=xml)
     root = ET.parse(f).getroot().attrib['id']
     
-    print('Created GR#{0} with following submit requests: {1}'.format(str(root), ', '.join([str(i) for i in srids])))
+    print('Created GR#{0} with following submit requests: {1}'.format(str(root), ', '.join(map(str, srids)))
 
 def _group_add(self, grid, pkgs, opts):
     """

--- a/osc-group.py
+++ b/osc-group.py
@@ -357,14 +357,11 @@ def do_group(self, subcmd, opts, *args):
     
     "remove" (or "r") will remove SR#(s) from selected group request
     
-    "approve" will approve the GR# and thus all of its SR#s will be merged to factory
-    
     Usage:
             osc group list [GR#]
             osc group add [GR#] [package-name | Source:Repository:/ | SR#]
             osc group create "Name of the group" [package-name | Source:Repository:/ | SR#]
             osc group remove GR# [package-name | Source:Repository:/ | SR#]
-            osc group approve GR# FIXME: finish this command in obs first
 
     ${cmd_option_list}
     """
@@ -373,7 +370,7 @@ def do_group(self, subcmd, opts, *args):
         self._print_version()
 
     # available commands
-    cmds = ['list', 'l', 'add', 'a', 'create', 'c', 'remove', 'r', 'approve']
+    cmds = ['list', 'l', 'add', 'a', 'create', 'c', 'remove', 'r']
     if not args or args[0] not in cmds:
         raise oscerr.WrongArgs('Unknown grouping action. Choose one of the {0}.'.format(', '.join(cmds)))
 
@@ -385,8 +382,6 @@ def do_group(self, subcmd, opts, *args):
         min_args, max_args = 2, None
     elif cmd in ['create', 'c']:
         min_args, max_args = 2, None
-    elif cmd in ['approve']:
-        min_args, max_args = 1, 1
     else:
         raise oscerr.WrongArgs('Unknown command: {0}'.format(cmd))
     if len(args) - 1 < min_args:
@@ -409,8 +404,6 @@ def do_group(self, subcmd, opts, *args):
         self._group_remove(args[1], args[2:], opts)
     elif cmd in ['create', 'c']:
         self._group_create(args[1], args[2:], opts)
-    elif cmd in ['approve']:
-        self._group_approve(args[1], opts)
 
 #Local Variables:
 #mode: python


### PR DESCRIPTION
The functionality now can list content of one grouping request:

root@bugaboo: ~ # osc group list 196531
GR#196531 | scarabeus_factory | 2013-08-27T08:54:35 | testing group

Contains following requests:
SR#196485 | server:database/sqlite3:77 | mvyskocil | 2013-08-27T07:38:29 | new
SR#196359 | devel:tools/doxygen:68 | factory-repo-checker | 2013-08-26T09:42:02 | new
