### PR TITLE
Manage package in unknown state

### DIFF
--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -600,6 +600,9 @@ def _check_repo_buildsuccess(self, p, opts):
                 print 'DECLINED', msg
                 self._check_repo_change_review_state(opts, p.request, 'new', message=msg)
                 return False
+            if arch.attrib['result'] == 'unknown':
+                print 'UNKOWN state -- Stoping check for this package'
+                return False
 
         r_missings = r_missings.keys()
         for pkg in r_missings:


### PR DESCRIPTION
There are packages that can be in an unknown state, for example 197495:Java:packages/apache-commons-collections

osc cr 197495
