### PR TITLE
Add missing includes so it does not bail out on Gentoo

### DIFF
--- a/osc-plugin-checkupdate.py
+++ b/osc-plugin-checkupdate.py
@@ -18,6 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import osc
+import osc.core
+import urllib2
+
+from osc import cmdln
+from osc import conf
+
 def _xxx_diff_filter_changes(self, diff):
     lines = []
     ischanges = False


### PR DESCRIPTION
As per summary this didn't work for me on debian and G so fixing it for others to use :)
