### PR TITLE
Make the source-checker aware of bnc entries which are invisible

### DIFF
--- a/osc-check_source.py
+++ b/osc-check_source.py
@@ -143,7 +143,7 @@ def _checker_one_request(self, rq, cmd, opts):
             if os.path.exists(dir):
                 print("%s already exists" % dir)
                 continue
-            os.mkdir(dir)
+            os.makedirs(dir)
             os.chdir(dir)
             try:
                 checkout_package(opts.apiurl, tprj, tpkg, pathname=dir,

--- a/osc-group.py
+++ b/osc-group.py
@@ -77,13 +77,16 @@ def _group_find_request_project(self, source_project, opts):
     :param opts: obs options
     """
 
-    url = makeurl(opts.apiurl, ['request'], 'states=new,review&project=openSUSE:Factory&view=collection&project={0}'.format(project))
+    url = makeurl(opts.apiurl, ['request'], 'states=new,review&project=openSUSE:Factory&view=collection')
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
     res = []
     for rq in root.findall('request'):
-        res.append(int(rq.attrib['id']))
+        for a in rq.findall('action'):
+            s = a.find('source')
+            if s is not None and s.get('project') == source_project:
+                res.append(int(rq.attrib['id']))
 
     if len(res) == 0:
         #raise oscerr.WrongArgs('There are no requests for base project "{0}"'.format(source_project))

--- a/osc-group.py
+++ b/osc-group.py
@@ -77,16 +77,13 @@ def _group_find_request_project(self, source_project, opts):
     :param opts: obs options
     """
 
-    url = makeurl(opts.apiurl, ['request'], 'states=new,review&project=openSUSE:Factory&view=collection')
+    url = makeurl(opts.apiurl, ['request'], 'states=new,review&project=openSUSE:Factory&view=collection&project={0}'.format(project))
     f = http_GET(url)
     root = ET.parse(f).getroot()
 
     res = []
     for rq in root.findall('request'):
-        for a in rq.findall('action'):
-            s = a.find('source')
-            if s is not None and s.get('project') == source_project:
-                res.append(int(rq.attrib['id']))
+        res.append(int(rq.attrib['id']))
 
     if len(res) == 0:
         #raise oscerr.WrongArgs('There are no requests for base project "{0}"'.format(source_project))

--- a/source-checker.pl
+++ b/source-checker.pl
@@ -106,26 +106,27 @@ for my $spec (glob ("$dir/*.spec")) {
 
 my $result;
 foreach (@bugs) {
-	# curl the state
-	$result = `curl --silent --head "https://bugzilla.novell.com/show_bug.cgi?id=$_" 2>&1`;
-	# only if curl succeeded do the check, bugzie down too much to be reliable
-	if ($? == 0) {
-		#if we have the ichain location then we actually need to login
-		if ($result =~ m/Location: ichainlogin.cgi/) {
-			push(@failing_bugs, $_);
-			next;
-		}
-		#if we get anything not like 200 on result we fail the pkg
-		my $check = ($result =~ m/HTTP\/1.1 200 OK/);
-		if (!$check) {
-			push(@failing_bugs, $_);
-		}
-	}
+    # curl the state
+    $result = `curl --silent --head "https://bugzilla.novell.com/show_bug.cgi?id=$_" 2>&1`;
+    # only if curl succeeded do the check, bugzie down too much to be reliable
+    if ($? == 0) {
+        #if we have the ichain location then we actually need to login
+        if ($result =~ m/Location: ichainlogin.cgi/) {
+            push(@failing_bugs, $_);
+            next;
+        }
+        #if we get anything not like 200 on result we fail the pkg
+        my $check = ($result =~ m/HTTP\/1.1 200 OK/);
+        if (!$check) {
+            push(@failing_bugs, $_);
+        }
+    }
 }
 
 if (scalar(@failing_bugs) > 0) {
-	print "Package contains following bnc# entries which are not visible for community: ".join( ', ', @failing_bugs);
-	exit(1);
+    print "Package contains following bnc# entries which are not visible for community: ".join( ', ', @failing_bugs);
+    print "For explanation please visit http://lists.opensuse.org/opensuse-packaging/2013-11/msg00042.html";
+    exit(1);
 }
 
 if ($spec !~ m/\n%changelog\s/ && $spec != m/\n%changelog$/) {


### PR DESCRIPTION
Fixes the https://progress.opensuse.org/issues/571.

Also that nov13/nov14 commits are there on purpose so I don't try to be clever next time because I will see that I tried and it was wrong :)
